### PR TITLE
Ensure tx1 is node1 mempool

### DIFF
--- a/ds_simulator.m
+++ b/ds_simulator.m
@@ -121,6 +121,7 @@ for h = 1:loopcount
         if count == 1
             for j = 1:size(coinnet(1).conn,2)
                 coinnet(1).conn(j).inv = [coinnet(1).conn(j).inv,1001];
+                coinnet(1).mempool = [coinnet(1).mempool,1001];
             end
         end
         


### PR DESCRIPTION
Without this line `ds_simulator(2, 2, 1, n, 0, false, true)` will always result in 0% of nodes receiving tx1 first.